### PR TITLE
Fix taxi availability update

### DIFF
--- a/taxi/taxi.py
+++ b/taxi/taxi.py
@@ -69,8 +69,15 @@ def listen_for_assignments():
         if assignment["taxi_id"] == TAXI_ID:
             print(f"Asignación recibida: {assignment}")
             destination = assignment["destination"]
+            # Marcar el taxi como ocupado y notificar al Central
+            taxi_state["available"] = False
+            producer.send('TAXI_POSITIONS', taxi_state)
+
             update_position(destination)
-            taxi_state["available"] = True  # Liberar taxi al terminar
+
+            # Liberar taxi al terminar y notificar su disponibilidad
+            taxi_state["available"] = True
+            producer.send('TAXI_POSITIONS', taxi_state)
 
 if __name__ == "__main__":
     # Publicar estado inicial


### PR DESCRIPTION
## Summary
- mark taxi unavailable when an assignment is received
- notify central when taxi becomes available again

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kafka')*

------
https://chatgpt.com/codex/tasks/task_e_68441daad40c832aa3df8b116406e972