### PR TITLE
Implement full trip workflow for taxis

### DIFF
--- a/central/central.py
+++ b/central/central.py
@@ -82,8 +82,12 @@ def process_taxi_message(message):
 def process_customer_message(message):
     """Procesar solicitudes de clientes."""
     client_id = message['client_id']
-    destination = message['pickup_location']
-    clients[client_id] = destination
+    pickup = message['pickup_location']
+    final_destination = message.get('destination')
+    clients[client_id] = {
+        "pickup_location": pickup,
+        "destination": final_destination,
+    }
 
     # Asignar taxi
     assigned_taxi = None
@@ -96,7 +100,8 @@ def process_customer_message(message):
         response = {
             "client_id": client_id,
             "taxi_id": assigned_taxi,
-            "destination": destination
+            "pickup_location": pickup,
+            "destination": final_destination,
         }
         producer.send('TAXI_ASSIGNMENTS', response)
         logging.info(f"Assigned Taxi {assigned_taxi} to Client {client_id}")

--- a/customer/customer.py
+++ b/customer/customer.py
@@ -55,7 +55,12 @@ def listen_for_assignments():
     for message in consumer:
         assignment = message.value
         if assignment["client_id"] == CLIENT_ID:
-            print(f"Asignación recibida: Taxi {assignment['taxi_id']} va a {assignment['destination']}")
+            pickup = assignment.get("pickup_location")
+            final_dest = assignment.get("destination")
+            print(
+                f"Asignación recibida: Taxi {assignment['taxi_id']} "
+                f"recogerá en {pickup} y llevará a {final_dest}"
+            )
 
 if __name__ == "__main__":
     print(f"Cliente {CLIENT_ID} iniciado...")

--- a/customer/requests.json
+++ b/customer/requests.json
@@ -1,5 +1,5 @@
 [
-    {"pickup_location": {"x": 10, "y": 15}},
-    {"pickup_location": {"x": 5, "y": 8}},
-    {"pickup_location": {"x": 20, "y": 20}}
+    {"pickup_location": {"x": 10, "y": 15}, "destination": {"x": 2, "y": 3}},
+    {"pickup_location": {"x": 5, "y": 8}, "destination": {"x": 7, "y": 1}},
+    {"pickup_location": {"x": 18, "y": 18}, "destination": {"x": 0, "y": 0}}
 ]

--- a/taxi/taxi.py
+++ b/taxi/taxi.py
@@ -68,9 +68,15 @@ def listen_for_assignments():
         assignment = message.value
         if assignment["taxi_id"] == TAXI_ID:
             print(f"Asignación recibida: {assignment}")
-            destination = assignment["destination"]
-            update_position(destination)
+            pickup = assignment["pickup_location"]
+            final_dest = assignment.get("destination")
+            taxi_state["available"] = False
+            producer.send('TAXI_POSITIONS', taxi_state)
+            update_position(pickup)
+            if final_dest:
+                update_position(final_dest)
             taxi_state["available"] = True  # Liberar taxi al terminar
+            producer.send('TAXI_POSITIONS', taxi_state)
 
 if __name__ == "__main__":
     # Publicar estado inicial

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,5 +1,6 @@
 import os
 import time
+import json
 from kafka import KafkaConsumer, KafkaProducer
 
 KAFKA_BROKER = os.getenv('KAFKA_BROKER', 'kafka:9092')
@@ -9,7 +10,11 @@ def test_functional():
     consumer = KafkaConsumer('TAXI_ASSIGNMENTS', bootstrap_servers=KAFKA_BROKER, value_deserializer=lambda v: json.loads(v.decode('utf-8')))
 
     # Enviar solicitud de cliente
-    client_request = {"client_id": 1, "pickup_location": {"x": 5, "y": 5}}
+    client_request = {
+        "client_id": 1,
+        "pickup_location": {"x": 5, "y": 5},
+        "destination": {"x": 1, "y": 1},
+    }
     producer.send('CUSTOMER_REQUESTS', client_request)
     print("Client request sent")
 


### PR DESCRIPTION
## Summary
- handle pickup and final destination in central when assigning taxis
- make taxi follow pickup then destination
- display pickup & destination in customer output
- update example request data and functional test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kafka')*

------
https://chatgpt.com/codex/tasks/task_e_6844240f14e8832a9f81061edba7535d