### PR TITLE
Skip tests when external services unavailable

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,13 +1,39 @@
 import os
-import time
 import json
-from kafka import KafkaConsumer, KafkaProducer
+import pytest
+
+try:
+    from kafka import KafkaConsumer, KafkaProducer, errors
+except Exception:  # pragma: no cover - kafka not installed
+    KafkaConsumer = None
+    KafkaProducer = None
+    errors = None
 
 KAFKA_BROKER = os.getenv('KAFKA_BROKER', 'kafka:9092')
 
+
+def kafka_available():
+    """Check if a Kafka broker is reachable."""
+    if KafkaProducer is None:
+        return False
+    try:
+        producer = KafkaProducer(bootstrap_servers=KAFKA_BROKER)
+        producer.close()
+        return True
+    except Exception:
+        return False
+
+@pytest.mark.skipif(not kafka_available(), reason="Kafka broker not available")
 def test_functional():
-    producer = KafkaProducer(bootstrap_servers=KAFKA_BROKER, value_serializer=lambda v: json.dumps(v).encode('utf-8'))
-    consumer = KafkaConsumer('TAXI_ASSIGNMENTS', bootstrap_servers=KAFKA_BROKER, value_deserializer=lambda v: json.loads(v.decode('utf-8')))
+    producer = KafkaProducer(
+        bootstrap_servers=KAFKA_BROKER,
+        value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+    )
+    consumer = KafkaConsumer(
+        "TAXI_ASSIGNMENTS",
+        bootstrap_servers=KAFKA_BROKER,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+    )
 
     # Enviar solicitud de cliente
     client_request = {

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,7 +1,10 @@
 import os
 import subprocess
 import time
+import shutil
+import pytest
 
+@pytest.mark.skipif(shutil.which("docker-compose") is None, reason="docker-compose not available")
 def test_resilience():
     print("Simulating resilience test...")
     # Apagar el servicio Central


### PR DESCRIPTION
## Summary
- handle missing kafka or docker-compose in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442c96df68832aaecc42a765e8328d