### PR TITLE
Remove node-fetch dependency

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,6 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "node-fetch": "^3.3.2"
+    "express": "^4.18.2"
   }
 }

--- a/front/server.js
+++ b/front/server.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const path = require('path');
-const fetch = require('node-fetch');
 
 const app = express();
 const PORT = process.env.FRONT_PORT || 3000;


### PR DESCRIPTION
## Summary
- update `front/server.js` to rely on Node's built-in `fetch`
- drop `node-fetch` from `front/package.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684457f2d92c832aa9faff9ad75ca800